### PR TITLE
Add SHACL tests

### DIFF
--- a/shapes/shacl/avoid_class_extension.shacl.ttl
+++ b/shapes/shacl/avoid_class_extension.shacl.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+# TODO:
+# - Could there be a way to test for a distinct shapes namespace?
+# - Could there be a way to test for a freestanding property shape?
+# - Could there be a way to test if every class is mirrored by a shape?
+
+# this is as close we can get to the semantics of the rule
+# i.e. any other type declared implies the shape is an extension
+# TODO:
+# - Also reproduce this for DatatypeProperty, ObjectProperty?
+# - Could there be a better way to express that something cannot be both?
+ex:AvoidClassExtensionShape
+  a sh:NodeShape ;
+  sh:targetClass sh:NodeShape ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:message "Non-observance of SEMIC rule DSC-R4: Avoid classes extended as node shapes" ;
+    sh:severity sh:Warning ;
+    sh:in (sh:NodeShape) ;
+  ] .

--- a/shapes/shacl/severity_declaration_exists.shacl.ttl
+++ b/shapes/shacl/severity_declaration_exists.shacl.ttl
@@ -14,12 +14,14 @@ ex:SeverityDeclarationExistsShape
       sh:property [
         sh:path sh:severity ;
         sh:minCount 1 ;
+        sh:maxCount 1 ;
       ]
     ]
     [
       sh:property [
         sh:path (sh:property sh:severity) ;
         sh:minCount 1 ;
+        sh:maxCount 1 ;
         ]
     ]
   )

--- a/shapes/shacl/severity_declaration_exists.shacl.ttl
+++ b/shapes/shacl/severity_declaration_exists.shacl.ttl
@@ -6,12 +6,21 @@
 
 ex:SeverityDeclarationExistsShape
   a sh:NodeShape ;
-  sh:targetClass sh:PropertyShape ;
-  sh:property [
-    sh:path sh:severity ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:message "Non-observation of SEMIC rule DSC-R5: Data shapes should be assigned a level of severity" ;
-    sh:severity sh:Warning ;
-  ] .
-  
+  sh:targetClass sh:NodeShape ;
+  sh:severity sh:Warning ;
+  sh:message "Non-observation of SEMIC rule DSC-R5: Data shapes should be assigned a level of severity" ;
+  sh:xone (
+    [
+      sh:property [
+        sh:path sh:severity ;
+        sh:minCount 1 ;
+      ]
+    ]
+    [
+      sh:property [
+        sh:path (sh:property sh:severity) ;
+        sh:minCount 1 ;
+        ]
+    ]
+  )
+.

--- a/shapes/shacl/severity_declaration_exists.shacl.ttl
+++ b/shapes/shacl/severity_declaration_exists.shacl.ttl
@@ -1,0 +1,17 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+ex:SeverityDeclarationExistsShape
+  a sh:NodeShape ;
+  sh:targetClass sh:PropertyShape ;
+  sh:property [
+    sh:path sh:severity ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:message "Non-observation of SEMIC rule DSC-R5: Data shapes should be assigned a level of severity" ;
+    sh:severity sh:Warning ;
+  ] .
+  

--- a/shapes/shacl/shape_declarations_exist.shacl.ttl
+++ b/shapes/shacl/shape_declarations_exist.shacl.ttl
@@ -1,0 +1,42 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+# this is overlapped by SC-R2 only_owl_resources which is a subset
+# but caters to use cases where both ontology and shapes are in one file/graph
+# TODO: perhaps this is redundant and can instead be a common shape?
+ex:OnlyOWLSHACLResourcesShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf rdf:type ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:message "Violation of SEMIC rule DSC-R1: Only SHACL (and OWL) class and property declarations shall be used" ;
+    sh:in (owl:Ontology owl:Class owl:DatatypeProperty owl:ObjectProperty owl:AnnotationProperty rdfs:Datatype sh:NodeShape sh:PropertyShape) ;
+  ] .
+
+ex:NodeShapeExistsShape
+  a sh:NodeShape ;
+  sh:targetNode sh:NodeShape ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+    sh:message "Violation of SEMIC rule DSC-R1: SHACL shape declarations shall exist" ;
+  ]
+.
+
+# # this does not make sense because a shapes file may not have property shapes
+# # TODO: but if there are no node shapes, can there be standalone property shapes?
+# #       perhaps that is the subject of SEMIC rule DSC-R4 where "freestanding" is mentioned?
+# #       (i.e. should it be node OR property shape exists?)
+# ex:PropertyShapeExistsShape
+#   a sh:NodeShape ;
+#   sh:targetNode sh:PropertyShape ;
+#   sh:property [
+#     sh:path [ sh:inversePath rdf:type ] ;
+#     sh:minCount 1 ;
+#     sh:message "Non-observance of SEMIC rule DSC-R1: SHACL property declarations shall exist" ;
+#     sh:severity sh:Warning ;
+#   ]
+# .

--- a/tests/test_data/shacl/avoid_class_extension/avoid_class_extension_correct.ttl
+++ b/tests/test_data/shacl/avoid_class_extension/avoid_class_extension_correct.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.org/> .
+@prefix exsh: <http://example.org/shapes/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Person a owl:Class .
+exsh:Person a sh:NodeShape .

--- a/tests/test_data/shacl/avoid_class_extension/avoid_class_extension_wrong.ttl
+++ b/tests/test_data/shacl/avoid_class_extension/avoid_class_extension_wrong.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.org/> .
+@prefix exsh: <http://example.org/shapes/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Person a owl:Class .
+ex:Person a sh:NodeShape .

--- a/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_correct.ttl
+++ b/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_correct.ttl
@@ -3,5 +3,13 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-exsh:Person a sh:PropertyShape .
-exsh:Person sh:severity sh:Warning .
+exsh:ValidNodeShapeWOProperty a sh:NodeShape .
+exsh:ValidNodeShapeWOProperty sh:severity sh:Warning .
+
+exsh:ValidNodeShapeWPropertyNamed a sh:NodeShape .
+exsh:ValidNodeShapeWPropertyNamed sh:property exsh:ValidPropertyShape .
+exsh:ValidPropertyShape a sh:PropertyShape .
+exsh:ValidPropertyShape sh:severity sh:Warning .
+
+exsh:ValidNodeShapeWPropertyBNode a sh:NodeShape .
+exsh:ValidNodeShapeWPropertyBNode sh:property [ sh:severity sh:Warning ] .

--- a/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_correct.ttl
+++ b/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_correct.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.org/> .
+@prefix exsh: <http://example.org/shapes/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+exsh:Person a sh:PropertyShape .
+exsh:Person sh:severity sh:Warning .

--- a/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_wrong.ttl
+++ b/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_wrong.ttl
@@ -3,4 +3,11 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-exsh:Person a sh:PropertyShape .
+exsh:InvalidNodeShapeWOProperty a sh:NodeShape .
+
+exsh:InvalidNodeShapeWPropertyNamed a sh:NodeShape .
+exsh:InvalidNodeShapeWPropertyNamed sh:property exsh:InvalidPropertyShape .
+exsh:InvalidPropertyShape a sh:PropertyShape .
+
+exsh:InvalidNodeShapeWPropertyBNode a sh:NodeShape .
+exsh:InvalidNodeShapeWPropertyBNode sh:property [ sh:message "I got no severity" ] .

--- a/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_wrong.ttl
+++ b/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_wrong.ttl
@@ -1,0 +1,6 @@
+@prefix ex: <http://example.org/> .
+@prefix exsh: <http://example.org/shapes/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+exsh:Person a sh:PropertyShape .

--- a/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_wrong.ttl
+++ b/tests/test_data/shacl/severity_declaration_exists/severity_declaration_exists_wrong.ttl
@@ -11,3 +11,10 @@ exsh:InvalidPropertyShape a sh:PropertyShape .
 
 exsh:InvalidNodeShapeWPropertyBNode a sh:NodeShape .
 exsh:InvalidNodeShapeWPropertyBNode sh:property [ sh:message "I got no severity" ] .
+
+exsh:InvalidNodeShapeWPropertyMultiSeverities a sh:NodeShape .
+exsh:InvalidNodeShapeWPropertyMultiSeverities sh:property [
+  sh:message "I got no severity"  ;
+  sh:severity sh:Warning ;
+  sh:severity sh:Violation ;
+] .

--- a/tests/test_data/shacl/shape_declarations_exist/shape_declarations_exist_correct.ttl
+++ b/tests/test_data/shacl/shape_declarations_exist/shape_declarations_exist_correct.ttl
@@ -1,0 +1,7 @@
+@prefix ex: <http://example.org/> .
+@prefix exsh: <http://example.org/shapes/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Person a owl:Class .
+exsh:Person a sh:NodeShape .

--- a/tests/test_data/shacl/shape_declarations_exist/shape_declarations_exist_wrong.ttl
+++ b/tests/test_data/shacl/shape_declarations_exist/shape_declarations_exist_wrong.ttl
@@ -1,0 +1,6 @@
+@prefix ex: <http://example.org/> .
+@prefix exsh: <http://example.org/shapes/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Person a owl:Class .

--- a/tests/unit/shacl/__init__.py
+++ b/tests/unit/shacl/__init__.py
@@ -1,0 +1,6 @@
+import pathlib
+
+from tests import SHAPES_FOLDER
+
+TEST_DATA_FOLDER = pathlib.Path(__file__).parent.parent.parent / "test_data" / "shacl"
+SHAPES_FOLDER = SHAPES_FOLDER / "shacl"

--- a/tests/unit/shacl/test_avoid_class_extension.py
+++ b/tests/unit/shacl/test_avoid_class_extension.py
@@ -1,0 +1,49 @@
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests.unit.shacl import TEST_DATA_FOLDER, SHAPES_FOLDER
+
+TEST_FILE_NAME = "avoid_class_extension"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdfs:Resource` becomes a violation
+    conforms, report_graph, report_text = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    conforms, _, _ = validate(wrong_data, shacl_graph=shacl_data)
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/shacl/test_severity_declaration_exists.py
+++ b/tests/unit/shacl/test_severity_declaration_exists.py
@@ -1,0 +1,49 @@
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests.unit.shacl import TEST_DATA_FOLDER, SHAPES_FOLDER
+
+TEST_FILE_NAME = "severity_declaration_exists"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdfs:Resource` becomes a violation
+    conforms, report_graph, report_text = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    conforms, _, _ = validate(wrong_data, shacl_graph=shacl_data)
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/shacl/test_severity_declaration_exists.py
+++ b/tests/unit/shacl/test_severity_declaration_exists.py
@@ -1,8 +1,10 @@
+import json
+
 import pytest
 from pyshacl import validate
 from rdflib import Graph
 
-from tests.unit.shacl import TEST_DATA_FOLDER, SHAPES_FOLDER
+from tests.unit.shacl import SHAPES_FOLDER, TEST_DATA_FOLDER
 
 TEST_FILE_NAME = "severity_declaration_exists"
 TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
@@ -39,10 +41,20 @@ def test_shacl_validation_correct(shacl_data, correct_data):
 
 def test_shacl_validation_wrong(shacl_data, wrong_data):
     # Validate incorrect RDF data against SHACL shapes
-    conforms, _, _ = validate(wrong_data, shacl_graph=shacl_data)
+    conforms, report_graph, report_text = validate(wrong_data, shacl_graph=shacl_data)
+
+    print(report_text)
+
+    result_list = json.loads(report_graph.serialize(format="json-ld"))
+    results_count = (
+        len(result_list[0]["http://www.w3.org/ns/shacl#result"]) if not conforms else 0
+    )
 
     # Assert that the data does not conform to the shapes
     assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+    # assert number of report results
+    assert results_count == 3
 
 
 if __name__ == "__main__":

--- a/tests/unit/shacl/test_severity_declaration_exists.py
+++ b/tests/unit/shacl/test_severity_declaration_exists.py
@@ -54,7 +54,7 @@ def test_shacl_validation_wrong(shacl_data, wrong_data):
     assert not conforms, "SHACL validation succeeded, but it should have failed"
 
     # assert number of report results
-    assert results_count == 3
+    assert results_count == 4
 
 
 if __name__ == "__main__":

--- a/tests/unit/shacl/test_shape_declarations_exist.py
+++ b/tests/unit/shacl/test_shape_declarations_exist.py
@@ -1,0 +1,49 @@
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests.unit.shacl import TEST_DATA_FOLDER, SHAPES_FOLDER
+
+TEST_FILE_NAME = "shape_declarations_exist"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdfs:Resource` becomes a violation
+    conforms, report_graph, report_text = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    conforms, _, _ = validate(wrong_data, shacl_graph=shacl_data)
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
- There must exist at least one NodeShape
- There should not be additional types declared on a NodeShape
- By extension, there should not be types beyond OWL and SHACL
- There should be a severity declared in any shape

SEMIC rules: DSC-R1, DSC-R4 (partial), DSC-R5