### PR TITLE
Add more OWL tests

### DIFF
--- a/shapes/owl/min_ontology_header.shacl.ttl
+++ b/shapes/owl/min_ontology_header.shacl.ttl
@@ -11,6 +11,9 @@
 # these are "derived" recommendations from the rule based on best practice
 # combining what is limited by the conventions and what for e.g. ePO uses
 
+# upper cardinalities are not tested as they wouldn't be caught
+# because other incorrect states exist in the same test file
+
 ex:MinOntologyHeaderShape
   a sh:NodeShape ;
   sh:targetClass owl:Ontology ;
@@ -23,6 +26,7 @@ ex:MinOntologyHeaderShape
     sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (owl:versionInfo <xsd:string>)" ;
     sh:severity sh:Warning ;
     sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] ;
 
   sh:property [
@@ -31,6 +35,7 @@ ex:MinOntologyHeaderShape
     sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (owl:versionIRI <xsd:anyURI>)" ;
     sh:severity sh:Warning ;
     sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] ;
 
   # Provenance metadata
@@ -41,6 +46,7 @@ ex:MinOntologyHeaderShape
     sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:created <xsd:date>)" ;
     sh:severity sh:Warning ;
     sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] ;
 
   sh:property [
@@ -49,6 +55,7 @@ ex:MinOntologyHeaderShape
     sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:issued <xsd:date>)" ;
     sh:severity sh:Warning ;
     sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] ;
 
   sh:property [
@@ -57,9 +64,13 @@ ex:MinOntologyHeaderShape
     sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:publisher <xsd:string>)" ;
     sh:severity sh:Warning ;
     sh:minCount 1 ;
+    sh:maxCount 1 ;
   ] ;
 
   # Descriptive metadata
+  # the upper cardinalities are not restricted as SHACL doesn't check if
+  # language tags are the same. if per-tag cardinality is to be enforced
+  # then something like max_one_label has to be done, which is more complex
 
   sh:property [
     sh:path dct:title ;
@@ -78,6 +89,8 @@ ex:MinOntologyHeaderShape
   ] ;
 
   # Licensing information
+  # while dct may not prescribe a cardinality for this it is safe
+  # to assume one can expect multiple licenses, so no upper cardinality here
 
   sh:property [
     sh:path dct:license ;

--- a/shapes/owl/min_ontology_header.shacl.ttl
+++ b/shapes/owl/min_ontology_header.shacl.ttl
@@ -1,0 +1,88 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# these are "derived" recommendations from the rule based on best practice
+# combining what is limited by the conventions and what for e.g. ePO uses
+
+ex:MinOntologyHeaderShape
+  a sh:NodeShape ;
+  sh:targetClass owl:Ontology ;
+
+  # Versioning metadata
+
+  sh:property [
+    sh:path owl:versionInfo ;
+    sh:datatype xsd:string ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (owl:versionInfo <xsd:string>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path owl:versionIRI ;
+    sh:nodeKind sh:IRI ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (owl:versionIRI <xsd:anyURI>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  # Provenance metadata
+
+  sh:property [
+    sh:path dct:created ;
+    sh:datatype xsd:date ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:created <xsd:date>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path dct:issued ;
+    sh:datatype xsd:date ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:issued <xsd:date>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path dct:publisher ;
+    sh:datatype xsd:string ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:publisher <xsd:string>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  # Descriptive metadata
+
+  sh:property [
+    sh:path dct:title ;
+    sh:datatype rdf:langString ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:title <rdf:langString>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  sh:property [
+    sh:path dct:description ;
+    sh:datatype rdf:langString ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:title <rdf:langString>)" ;
+    sh:severity sh:Warning ;
+    sh:minCount 1 ;
+  ] ;
+
+  # Licensing information
+
+  sh:property [
+    sh:path dct:license ;
+    sh:datatype xsd:string ;
+    sh:severity sh:Warning ;
+    sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall include a minimum header (dct:license <xsd:string>)" ;
+    sh:minCount 1 ;
+  ] .

--- a/shapes/owl/no_advanced_definitions.shacl.ttl
+++ b/shapes/owl/no_advanced_definitions.shacl.ttl
@@ -1,0 +1,54 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:NoAdvancedDefinitionsShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf rdf:type ;
+  sh:property [
+    sh:path [
+      sh:alternativePath (
+        owl:unionOf
+        owl:complementOf
+        owl:equivalentClass
+        owl:disjointWith
+        owl:inverseOf
+        owl:oneOf
+        owl:sameAs
+        owl:hasKey
+        owl:cardinality
+        owl:minCardinality
+        owl:maxCardinality
+        owl:allValuesFrom
+        owl:someValuesFrom
+        owl:hasValue
+      )
+    ] ;
+    sh:maxCount 0 ;
+    sh:message "Violation of SEMIC rule SC-R2: Advanced logical definitions shall not be used" ;
+  ]
+.
+
+ex:NoBNodeSubsumptionShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf rdf:type ;
+  sh:property [
+    sh:path [ sh:alternativePath ( rdfs:subClassOf rdfs:subPropertyOf ) ] ;
+    sh:nodeKind sh:IRI ;
+    sh:message "Violation of SEMIC rule SC-R2: Advanced logical definitions shall not be used (bNodes in subsumption)" ;
+  ]
+.
+
+# the following are not allowed by derivation from SC-R2 only_owl_resources
+# owl:FunctionalProperty
+# owl:TransitiveProperty
+# owl:SymmetricProperty
+# owl:AsymmetricProperty
+# owl:ReflexiveProperty
+# owl:IrreflexiveProperty

--- a/shapes/owl/only_owl_ontology.shacl.ttl
+++ b/shapes/owl/only_owl_ontology.shacl.ttl
@@ -33,6 +33,7 @@ ex:OnlyOWLOntologyShape
   sh:property [
     sh:path [ sh:inversePath rdf:type ] ;
     sh:minCount 1 ;
+    sh:maxCount 1 ; # this is not currently tested due to single file
     sh:message "Violation of SEMIC rule SC-R1: Missing OWL ontology declaration" ;
   ]
 .

--- a/shapes/owl/select_few_expressions.shacl.ttl
+++ b/shapes/owl/select_few_expressions.shacl.ttl
@@ -1,0 +1,97 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Uncomment the individual property restrictions to imply "minimum required"
+
+ex:SelectFewExpressionsShape
+  rdf:type sh:NodeShape ;
+  sh:closed true ;
+  sh:ignoredProperties (rdf:type rdfs:subClassOf rdfs:subPropertyOf) ;
+  sh:severity sh:Warning ;
+  sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall be limited to a select few expressions" ;
+  sh:targetSubjectsOf rdf:type ;
+
+  # Concept labels
+  sh:property [
+    sh:path rdfs:label ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Concept labels (rdfs:label) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:prefLabel ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Concept labels (skos:prefLabel) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:altLabel ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Concept labels (skos:altLabel) are recommended." ;
+  ] ;
+
+  # Concept definitions
+  sh:property [
+    sh:path rdfs:comment ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Concept definitions (rdfs:comment) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:definition ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Concept definitions (skos:definition) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:scopeNote ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Concept definitions (skos:scopeNote) are recommended." ;
+  ] ;
+
+  # Notes and comments
+  sh:property [
+    sh:path rdfs:comment ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Notes and comments (rdfs:comment) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:editorialNote ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Notes and comments (skos:editorialNote) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:changeNote ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Notes and comments (skos:changeNote) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:historyNote ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Notes and comments (skos:historyNote) are recommended." ;
+  ] ;
+
+  sh:property [
+    sh:path skos:example ;
+    # sh:minCount 1 ;
+    # sh:severity sh:Warning ;
+    # sh:message "Notes and comments (skos:example) are recommended." ;
+  ] .

--- a/shapes/owl/select_few_expressions.shacl.ttl
+++ b/shapes/owl/select_few_expressions.shacl.ttl
@@ -5,6 +5,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
 # Uncomment the individual property restrictions to imply "minimum required"
 
@@ -94,4 +95,36 @@ ex:SelectFewExpressionsShape
     # sh:minCount 1 ;
     # sh:severity sh:Warning ;
     # sh:message "Notes and comments (skos:example) are recommended." ;
-  ] .
+  ] ;
+
+  # subsume also the minimum header properties (min_ontology_header)
+
+  sh:property [
+    sh:path owl:versionIRI ;
+  ] ;
+
+  sh:property [
+    sh:path dct:created ;
+  ] ;
+
+    sh:property [
+    sh:path dct:issued
+ ;
+  ] ;
+
+    sh:property [
+    sh:path dct:publisher ;
+  ] ;
+
+    sh:property [
+    sh:path dct:title ;
+  ] ;
+
+    sh:property [
+    sh:path dct:description ;
+  ] ;
+
+    sh:property [
+    sh:path dct:license ;
+  ] ;
+.

--- a/shapes/owl/select_few_expressions.shacl.ttl
+++ b/shapes/owl/select_few_expressions.shacl.ttl
@@ -11,7 +11,7 @@
 ex:SelectFewExpressionsShape
   rdf:type sh:NodeShape ;
   sh:closed true ;
-  sh:ignoredProperties (rdf:type rdfs:subClassOf rdfs:subPropertyOf) ;
+  sh:ignoredProperties (rdf:type rdfs:subClassOf rdfs:subPropertyOf rdfs:isDefinedBy owl:imports) ;
   sh:severity sh:Warning ;
   sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall be limited to a select few expressions" ;
   sh:targetSubjectsOf rdf:type ;

--- a/shapes/owl/select_few_expressions.shacl.ttl
+++ b/shapes/owl/select_few_expressions.shacl.ttl
@@ -13,7 +13,7 @@ ex:SelectFewExpressionsShape
   rdf:type sh:NodeShape ;
   sh:closed true ;
   sh:ignoredProperties (rdf:type rdfs:subClassOf rdfs:subPropertyOf rdfs:isDefinedBy owl:imports) ;
-  sh:severity sh:Warning ;
+  sh:severity sh:Info ;
   sh:message "Non-observance of SEMIC rule SC-R2: The ontology shall be limited to a select few expressions" ;
   sh:targetSubjectsOf rdf:type ;
 

--- a/shapes/owl/semantic_versioning.shacl.ttl
+++ b/shapes/owl/semantic_versioning.shacl.ttl
@@ -1,0 +1,22 @@
+@prefix ex: <http://example.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# second regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# handles x.y.z-rc1 but not z.y.z-rc.1 (both allowed by SemVer but maybe not in practice e.g. ePO)
+
+ex:SemanticVersioningShape
+  a sh:NodeShape ;
+  sh:targetClass owl:Ontology ;
+  sh:property [
+    sh:path owl:versionInfo ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:string ;
+    sh:pattern "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$" ;
+    sh:message "Violation of SEMIC rule PC-R3: The ontology shall be versioned following the SemVer specification" ;
+  ] .

--- a/tests/test_data/owl/min_ontology_header/min_ontology_header_correct.ttl
+++ b/tests/test_data/owl/min_ontology_header/min_ontology_header_correct.ttl
@@ -1,0 +1,16 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:ValidOntologyHeader a owl:Ontology ;
+  dct:created "2021-06-01"^^xsd:date ;
+  dct:description "This is a language-tagged description of an OWL ontology."@en ;
+  dct:issued "2023-12-19"^^xsd:date ;
+  dct:license "European Union Public Licence v1.2 (https://eupl.eu/)" ;
+  dct:publisher "http://publications.europa.eu/resource/authority/corporate-body/PUBL" ;
+  dct:title "A Very Special Ontology"@en ;
+  owl:versionIRI ex:core-4.1.0 ;
+  owl:versionInfo "4.1.0" .

--- a/tests/test_data/owl/min_ontology_header/min_ontology_header_wrong.ttl
+++ b/tests/test_data/owl/min_ontology_header/min_ontology_header_wrong.ttl
@@ -1,0 +1,18 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:InvalidOntologyNoHeader a owl:Ontology .
+
+ex:InvalidOntologyHeaderValues a owl:Ontology ;
+  dct:created "2021-06-01" ;
+  dct:description "This is a plain description of an OWL ontology." ;
+  dct:issued "2023-12-19"^^xsd:dateTime ;
+  dct:license "European Union Public Licence v1.2 (https://eupl.eu/)"@en ;
+  dct:publisher ex:core ;
+  dct:title "A Very Special Ontology" ;
+  owl:versionIRI "4.1.0" ;
+  owl:versionInfo 4.1 .

--- a/tests/test_data/owl/no_advanced_definitions/no_advanced_definitions_correct.ttl
+++ b/tests/test_data/owl/no_advanced_definitions/no_advanced_definitions_correct.ttl
@@ -1,0 +1,20 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Person a owl:Class .
+
+ex:Human a owl:Class .
+
+ex:Person rdfs:subClassOf ex:Human .
+
+ex:name a owl:DatatypeProperty .
+
+ex:givenName a owl:DatatypeProperty .
+
+ex:givenName rdfs:subPropertyOf ex:name .
+
+ex:hasFriend a owl:ObjectProperty .
+
+ex:note a owl:AnnotationProperty .

--- a/tests/test_data/owl/no_advanced_definitions/no_advanced_definitions_wrong.ttl
+++ b/tests/test_data/owl/no_advanced_definitions/no_advanced_definitions_wrong.ttl
@@ -1,0 +1,71 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+# Define classes Alpha, Beta, and Gamma
+ex:Alpha a owl:Class .
+ex:Beta a owl:Class .
+ex:Gamma a owl:Class .
+
+# Define a class Delta as the union of Alpha, Beta, and Gamma
+ex:Delta a owl:Class ;
+  owl:unionOf ( ex:Alpha ex:Beta ex:Gamma ) .
+
+# Define classes Apple and Banana
+ex:Apple a owl:Class .
+ex:Banana a owl:Class .
+
+# Define a class Fruit as the complement of Apple
+ex:Fruit a owl:Class ;
+  owl:complementOf ex:Apple .
+
+# Define classes Car and Automobile as equivalent
+ex:Car a owl:Class.
+ex:Automobile a owl:Class.
+
+ex:Car owl:equivalentClass ex:Automobile.
+
+# Define classes RedColor and BlueColor
+ex:RedColor a owl:Class.
+ex:BlueColor a owl:Class.
+
+# Declare that RedColor is disjoint with BlueColor
+ex:RedColor owl:disjointWith ex:BlueColor.
+
+# Individuals
+ex:Person1 a owl:Class .
+ex:Person2 a owl:Class .
+ex:Car1 a owl:Class .
+ex:Car2 a owl:Class .
+
+# Object Properties
+ex:hasOwner a owl:ObjectProperty .
+ex:owns a owl:ObjectProperty .
+
+# InverseOf Example
+ex:hasOwner owl:inverseOf ex:owns .
+
+# oneOf Example
+ex:Color a owl:Class ;
+         a owl:Class ;
+         owl:oneOf ( ex:Red ex:Green ex:Blue ) .
+
+# hasKey Example
+ex:Employee a owl:Class ;
+            owl:hasKey ( ex:employeeID ) .
+
+# SameAs Example
+ex:Person1 owl:sameAs ex:Person2 .
+
+ex:CarWOwner
+a owl:Class ;
+rdfs:subClassOf [
+  a owl:Restriction ;
+] .
+
+ex:carOwner
+a owl:ObjectProperty ;
+rdfs:subPropertyOf [
+  a owl:Restriction ;
+] .

--- a/tests/test_data/owl/only_owl_ontology/only_owl_ontology_wrong.ttl
+++ b/tests/test_data/owl/only_owl_ontology/only_owl_ontology_wrong.ttl
@@ -2,6 +2,11 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
+# this can't be tested as we use only one file
+# and the absence won't be tested in this case
+#ex:Ontology1 a owl:Ontology .
+#ex:Ontology2 a owl:Ontology .
+
 ex:Person rdfs:label "Person" .
 
 ex:name rdfs:label "name" .

--- a/tests/test_data/owl/select_few_expressions/select_few_expressions_correct.ttl
+++ b/tests/test_data/owl/select_few_expressions/select_few_expressions_correct.ttl
@@ -1,0 +1,46 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:ValidExpressiveClass
+  a owl:Class ;
+  rdfs:subClassOf owl:Thing ;
+  rdfs:label "Example Label" ;
+  skos:prefLabel "Preferred Label" ;
+  skos:altLabel "Alternative Label" ;
+  rdfs:comment "Example Comment" ;
+  skos:definition "Example Definition" ;
+  skos:scopeNote "Example Scope Note" ;
+  skos:editorialNote "Example Editorial Note" ;
+  skos:changeNote "Example Change Note" ;
+  skos:historyNote "Example History Note" ;
+  skos:example "Example Example" .
+
+ex:ValidExpressiveDataProperty
+  a owl:DatatypeProperty ;
+  rdfs:subPropertyOf owl:Thing ;
+  rdfs:label "Example Label" ;
+  skos:prefLabel "Preferred Label" ;
+  skos:altLabel "Alternative Label" ;
+  rdfs:comment "Example Comment" ;
+  skos:definition "Example Definition" ;
+  skos:scopeNote "Example Scope Note" ;
+  skos:editorialNote "Example Editorial Note" ;
+  skos:changeNote "Example Change Note" ;
+  skos:historyNote "Example History Note" ;
+  skos:example "Example Example" .
+
+ex:ValidExpressiveObjectProperty
+  a owl:DatatypeProperty ;
+  rdfs:subPropertyOf owl:Thing ;
+  rdfs:label "Example Label" ;
+  skos:prefLabel "Preferred Label" ;
+  skos:altLabel "Alternative Label" ;
+  rdfs:comment "Example Comment" ;
+  skos:definition "Example Definition" ;
+  skos:scopeNote "Example Scope Note" ;
+  skos:editorialNote "Example Editorial Note" ;
+  skos:changeNote "Example Change Note" ;
+  skos:historyNote "Example History Note" ;
+  skos:example "Example Example" .

--- a/tests/test_data/owl/select_few_expressions/select_few_expressions_wrong.ttl
+++ b/tests/test_data/owl/select_few_expressions/select_few_expressions_wrong.ttl
@@ -1,0 +1,49 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:InvalidExpressiveClass
+  a owl:Class ;
+  rdfs:subClassOf owl:Thing ;
+  rdfs:label "Example Label" ;
+  skos:prefLabel "Preferred Label" ;
+  skos:altLabel "Alternative Label" ;
+  rdfs:comment "Example Comment" ;
+  skos:definition "Example Definition" ;
+  skos:scopeNote "Example Scope Note" ;
+  skos:editorialNote "Example Editorial Note" ;
+  skos:changeNote "Example Change Note" ;
+  skos:historyNote "Example History Note" ;
+  skos:example "Example Example" ;
+  skos:seeAlso "asdasd" .
+
+ex:InvalidExpressiveDataProperty
+  a owl:DatatypeProperty ;
+  rdfs:subPropertyOf owl:Thing ;
+  rdfs:label "Example Label" ;
+  skos:prefLabel "Preferred Label" ;
+  skos:altLabel "Alternative Label" ;
+  rdfs:comment "Example Comment" ;
+  skos:definition "Example Definition" ;
+  skos:scopeNote "Example Scope Note" ;
+  skos:editorialNote "Example Editorial Note" ;
+  skos:changeNote "Example Change Note" ;
+  skos:historyNote "Example History Note" ;
+  skos:example "Example Example" ;
+  skos:seeAlso "asdasd" .
+
+ex:InvalidExpressiveObjectProperty
+  a owl:ObjectProperty ;
+  rdfs:subPropertyOf owl:Thing ;
+  rdfs:label "Example Label" ;
+  skos:prefLabel "Preferred Label" ;
+  skos:altLabel "Alternative Label" ;
+  rdfs:comment "Example Comment" ;
+  skos:definition "Example Definition" ;
+  skos:scopeNote "Example Scope Note" ;
+  skos:editorialNote "Example Editorial Note" ;
+  skos:changeNote "Example Change Note" ;
+  skos:historyNote "Example History Note" ;
+  skos:example "Example Example" ;
+  skos:seeAlso "asdasd" .

--- a/tests/test_data/owl/semantic_versioning/semantic_versioning_correct.ttl
+++ b/tests/test_data/owl/semantic_versioning/semantic_versioning_correct.ttl
@@ -1,0 +1,20 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:ValidVersionedOntologyStable
+  a owl:Ontology ;
+  owl:versionInfo "1.2.3" .
+
+ex:ValidVersionedOntologyRC
+  a owl:Ontology ;
+  owl:versionInfo "1.2.3-rc.1" .
+
+ex:ValidVersionedOntologyRCAlt1
+  a owl:Ontology ;
+  owl:versionInfo "1.2.3-rc1" .
+
+ex:InvalidVersionedOntologyRCAlt2
+  a owl:Ontology ;
+  owl:versionInfo "1.2.3-rc-1" .

--- a/tests/test_data/owl/semantic_versioning/semantic_versioning_wrong.ttl
+++ b/tests/test_data/owl/semantic_versioning/semantic_versioning_wrong.ttl
@@ -1,0 +1,32 @@
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:InvalidVersionedOntology
+  a owl:Ontology .
+
+ex:InvalidVersionedOntologyCommon
+  a owl:Ontology ;
+  owl:versionInfo "1.2" .
+
+ex:InvalidVersionedOntologyLazy
+  a owl:Ontology ;
+  owl:versionInfo "1" .
+
+ex:InvalidVersionedOntologyIdiotic
+  a owl:Ontology ;
+  owl:versionInfo "1.2.3.1" .
+
+ex:InvalidVersionedOntologyWords
+  a owl:Ontology ;
+  owl:versionInfo "alpha" .
+
+ex:InvalidVersionedOntologyRC
+  a owl:Ontology ;
+  owl:versionInfo "1.2.3-rc_1" .
+
+# this triggers two violations one for data type
+ex:InvalidVersionedOntologyNumbers
+  a owl:Ontology ;
+  owl:versionInfo 1.2 .

--- a/tests/unit/owl/test_min_ontology_header.py
+++ b/tests/unit/owl/test_min_ontology_header.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests import SHAPES_FOLDER
+from tests.unit.owl import TEST_DATA_FOLDER
+
+TEST_FILE_NAME = "min_ontology_header"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+SHAPES_FOLDER = SHAPES_FOLDER / "owl"
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdf:type` prevents violation
+    conforms, report_graph, _ = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdf:type` raises violation
+    conforms, report_graph, report_text = validate(wrong_data, shacl_graph=shacl_data)
+
+    print(report_text)
+
+    result_list = json.loads(report_graph.serialize(format="json-ld"))
+    results_count = len(result_list[0]["http://www.w3.org/ns/shacl#result"]) if not conforms else 0
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+    # assert number of report results
+    assert results_count == 16
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/owl/test_no_advanced_definitions.py
+++ b/tests/unit/owl/test_no_advanced_definitions.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests import SHAPES_FOLDER
+from tests.unit.owl import TEST_DATA_FOLDER
+
+TEST_FILE_NAME = "no_advanced_definitions"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+SHAPES_FOLDER = SHAPES_FOLDER / "owl"
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    conforms, report_graph, _ = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    conforms, report_graph, report_text = validate(wrong_data, shacl_graph=shacl_data)
+
+    print(report_text)
+
+    result_list = json.loads(report_graph.serialize(format="json-ld"))
+    results_count = len(result_list[0]["http://www.w3.org/ns/shacl#result"]) if not conforms else 0
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+    # assert number of report results
+    assert results_count == 10
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/owl/test_select_few_expressions.py
+++ b/tests/unit/owl/test_select_few_expressions.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests import SHAPES_FOLDER
+from tests.unit.owl import TEST_DATA_FOLDER
+
+TEST_FILE_NAME = "select_few_expressions"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+SHAPES_FOLDER = SHAPES_FOLDER / "owl"
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdf:type` prevents violation
+    conforms, report_graph, _ = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdf:type` raises violation
+    conforms, report_graph, report_text = validate(wrong_data, shacl_graph=shacl_data)
+
+    print(report_text)
+
+    result_list = json.loads(report_graph.serialize(format="json-ld"))
+    results_count = len(result_list[0]["http://www.w3.org/ns/shacl#result"]) if not conforms else 0
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+    # assert number of report results
+    assert results_count == 3
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/unit/owl/test_semantic_versioning.py
+++ b/tests/unit/owl/test_semantic_versioning.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+from pyshacl import validate
+from rdflib import Graph
+
+from tests import SHAPES_FOLDER
+from tests.unit.owl import TEST_DATA_FOLDER
+
+TEST_FILE_NAME = "semantic_versioning"
+TEST_DATA_FOLDER = TEST_DATA_FOLDER / TEST_FILE_NAME
+SHAPES_FOLDER = SHAPES_FOLDER / "owl"
+
+
+@pytest.fixture
+def shacl_data():
+    # Load your SHACL shapes
+    return Graph().parse(SHAPES_FOLDER / f"{TEST_FILE_NAME}.shacl.ttl", format="ttl")
+
+
+@pytest.fixture
+def correct_data():
+    # Load correct RDF data
+    return Graph().parse(
+        TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_correct.ttl", format="ttl"
+    )
+
+
+@pytest.fixture
+def wrong_data():
+    # Load incorrect RDF data
+    return Graph().parse(TEST_DATA_FOLDER / f"{TEST_FILE_NAME}_wrong.ttl", format="ttl")
+
+
+def test_shacl_validation_correct(shacl_data, correct_data):
+    # Validate correct RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdf:type` prevents violation
+    conforms, report_graph, _ = validate(correct_data, shacl_graph=shacl_data)
+
+    # Assert that the data conforms to the shapes
+    assert conforms, f"SHACL validation failed:\n{report_graph.serialize()}"
+
+
+def test_shacl_validation_wrong(shacl_data, wrong_data):
+    # Validate incorrect RDF data against SHACL shapes
+    # NOTE: No inference here otherwise `rdf:type` raises violation
+    conforms, report_graph, report_text = validate(wrong_data, shacl_graph=shacl_data)
+
+    print(report_text)
+
+    result_list = json.loads(report_graph.serialize(format="json-ld"))
+    results_count = len(result_list[0]["http://www.w3.org/ns/shacl#result"]) if not conforms else 0
+
+    # Assert that the data does not conform to the shapes
+    assert not conforms, "SHACL validation succeeded, but it should have failed"
+
+    # assert number of report results
+    assert results_count == 8
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
All part of SC-R2, unless otherwise prefixed:

- Limit expressions to a select few properties
- PC-R3 Require `owl:versionInfo` on any instance of `owl:Ontology` matching SemVer pattern
- Minimum ontology header
- Advanced OWL axioms

The following UML-Derived rules are currently unimplementable due to tooling issues (tentatively reported [on Discord](https://discord.com/channels/911006583067144212/911020976496586782/1204449907226845194)):
1. CMC-R3 URI encoding characters
2. CMC-R4 URI naming scheme